### PR TITLE
pwa: set serviceWorker false in cli

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -5,7 +5,7 @@
   },
   "apps": [
     {
-      "serviceWorker": true,
+      "serviceWorker": false,
       "root": "src",
       "outDir": "dist",
       "assets": ["assets", "favicon.ico", "manifest.json"],


### PR DESCRIPTION
Since abb36e3cb, running yarn start --prod will no longer set up the ServiceWorker, which would require manually running yarn sw-manifest and yarn sw-copy